### PR TITLE
Pass along the options when initializing plugins

### DIFF
--- a/lib/pluginHandler.js
+++ b/lib/pluginHandler.js
@@ -8,14 +8,18 @@ module.exports = {
         plugins.push(plugin);
     },
 
-    initPlugins : function (pluginApi) {
+    initPlugins : function (pluginApi, options) {
         if (!pluginApi) {
             throw new Error('Expected a PluginApi instance');
         }
         delete pluginApi._reset;
         if (Object.freeze) { Object.freeze(pluginApi); }
         plugins.forEach(function (plugin) {
-            plugin(pluginApi);
+            plugin(pluginApi, options || {});
         });
+    },
+
+    _reset: function () {
+        plugins.length = 0;
     }
 };

--- a/test/pluginHandler.test.js
+++ b/test/pluginHandler.test.js
@@ -2,8 +2,11 @@
 var pluginHandler = require('../lib/pluginHandler.js');
 var PluginApi     = require('../lib/PluginApi.js');
 
-
 describe('pluginHandler', function () {
+
+    afterEach(function () {
+        pluginHandler._reset();
+    });
 
     describe('register', function () {
         it('should be a method', function () {
@@ -52,7 +55,25 @@ describe('pluginHandler', function () {
             pluginHandler.register(spy);
             pluginHandler.initPlugins(pluginApi);
 
-            expect(spy).to.have.been.calledWithExactly(pluginApi);
+            expect(spy).to.have.been.calledWithExactly(pluginApi, {});
+        });
+
+        it('should pass an empty options object if initPlugins called without options', function (done) {
+            pluginHandler.register(function (pluginApi, options) {
+                expect(options).to.exist;
+                expect(options).to.be.empty;
+                done();
+            });
+            pluginHandler.initPlugins(new PluginApi());
+        });
+
+        it('should pass the options object along if initPlugins called with options', function (done) {
+            var opts = {foo: 'bar'};
+            pluginHandler.register(function (pluginApi, options) {
+                expect(options).to.equal(opts);
+                done();
+            });
+            pluginHandler.initPlugins(new PluginApi(), opts);
         });
 
         it('should remove _reset method from PluginApi before sending it to plugins', function () {


### PR DESCRIPTION
We're starting to see that passing config-options to plugins makes the code unnecessary complex. There is no defined way to do it. You will have to expose an extra method for configuration or have a higher-order function that returns the plugin pre-configured. See this example (higher-order function):

```
var gardrHost = require('gardr-host');
var examplePlugin = require('gardr-plugin-host-example');

gardrHost.plugin( examplePlugin({
    foo: 'bar'
}) );

var myGardr = gardrHost({
    iframeUrl: '...'
});
```

I suggest we pass the options given to gardr-{host | ext} along when initializing plugins. Then it's just to add the extra options in the general configuration. It makes regestring plugins a lot easier, and configuration is in one place instead.

```
var gardrHost = require('gardr-host');
gardrHost.plugin( require('gardr-plugin-host-example') );

var myGardr = gardrHost({
    iframeUrl: '...',
    exampleFoo: 'bar'
});
```

A risk might be collision of options between plugins. But it's quite easy to detect, and we can suggest that plugins have a short prefix before their options. Having a deeper options-object will make the code more complex.

If a plugin still want to do it a higher-order function that's still fine. A plugin could also need to see the options object for other reasons.
