### PR TITLE
Support for async request-respond through post-message

### DIFF
--- a/lib/PluginApi.js
+++ b/lib/PluginApi.js
@@ -1,3 +1,4 @@
+var xde = require('cross-domain-events');
 var data = {};
 var i = 0;
 
@@ -30,12 +31,57 @@ function publish (id, subject) {
     });
 }
 
+
+ /**
+ *
+ * Gardr.reqres
+ *
+ * Request-response pattern for sending messages
+ * between gardr hostplugins and ext banners and plugins.
+ */
+
+ // Sends a message to otherWindow with params
+ // waits for the response, and calls callback upon that.
+ function request (otherWindow, subject, params, callback) {
+     xde.sendTo(otherWindow, 'gardr:' + subject, params)
+     xde.on('gardr:' + subject + ':response', callback);
+ }
+
+
+// listens to postmessages with subject
+// calls the given callback, and upon return
+// sends the result back
+function respondTo (subject, cb) {
+     xde.on('gardr:' + subject, onRespondToMsg(subject, cb))
+
+    function onRespondToMsg (subject, cb) {
+
+        return function (evt) {
+            // because cb can be async, it is responsible for
+            // triggering the _onCallbackComplete function
+            cb(evt, onCallbackComplete.bind(null, subject, evt));
+        }
+    }
+
+    function onCallbackComplete (subject, evt, res) {
+        xde.sendTo(evt.source, 'gardr:' + subject + ':response', res);
+    }
+}
+
+
 var PluginApi = function () {
     this.id = i++;
 
     set(this.id, 'listeners', {});
     this.on      = subscribe.bind(null, this.id);
-    this.trigger = publish.bind(null, this.id)
+    this.trigger = publish.bind(null, this.id);
+
+    // The reqres module enables gardr plugins to communicate after
+    // the banner has been document writed.
+    this.reqres = {
+        request : request,
+        respondTo : respondTo
+    }
 
     this._reset = function () { set(this.id, 'listeners', {}); };
 };

--- a/lib/PluginApi.js
+++ b/lib/PluginApi.js
@@ -42,16 +42,25 @@ function publish (id, subject) {
 
  // Sends a message to otherWindow with params
  // waits for the response, and calls callback upon that.
- function request (otherWindow, subject, params, callback) {
-     xde.sendTo(otherWindow, 'gardr:' + subject, params)
-     xde.on('gardr:' + subject + ':response', callback);
+ function postMessage (subject, params, callback, otherWindow) {
+     otherWindow = otherWindow || window.top;
+
+     try {
+         xde.sendTo(otherWindow, 'gardr:' + subject, params);
+
+         xde.on('gardr:' + subject + ':response', function (evt) {
+             callback(null, evt.data);
+         });
+     } catch(e) {
+         callback(e);
+     }
  }
 
 
 // listens to postmessages with subject
 // calls the given callback, and upon return
 // sends the result back
-function respondTo (subject, cb) {
+function respondToPostMessage (subject, cb) {
      xde.on('gardr:' + subject, onRespondToMsg(subject, cb))
 
     function onRespondToMsg (subject, cb) {
@@ -59,7 +68,7 @@ function respondTo (subject, cb) {
         return function (evt) {
             // because cb can be async, it is responsible for
             // triggering the _onCallbackComplete function
-            cb(evt, onCallbackComplete.bind(null, subject, evt));
+            cb(evt.data, onCallbackComplete.bind(null, subject, evt));
         }
     }
 
@@ -78,10 +87,8 @@ var PluginApi = function () {
 
     // The reqres module enables gardr plugins to communicate after
     // the banner has been document writed.
-    this.reqres = {
-        request : request,
-        respondTo : respondTo
-    }
+    this.postMessage = postMessage;
+    this.respondToPostMessage = respondToPostMessage;
 
     this._reset = function () { set(this.id, 'listeners', {}); };
 };

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "karma": "~0.12.1",
     "karma-browserifast": "~0.4.1",
     "es5-shim": "~2.3.0"
+  },
+  "dependencies": {
+    "cross-domain-events": "0.0.2"
   }
 }

--- a/test/PluginApi.test.js
+++ b/test/PluginApi.test.js
@@ -73,29 +73,37 @@ describe('PluginApi', function () {
             var reqData = {fooInt : 1337};
 
             it('should call request.callback with proper params when there is a responder', function (done) {
-                callRespondTo(api, evtName);
-                callRequest(api, evtName, reqData, 1338, done);
+                callRespondToPostMessage(api, evtName);
+                callPostMessage(api, evtName, reqData, 1338, done);
             });
         });
+
+        describe('errors', function () {
+            it('should catch xde errors', function () {
+                api.postMessage('test:event', {}, function (err) {
+                    expect(err).to.exist;
+                    expect(err.message).to.equal('otherWindow does not support postMessage');
+                }, 'not a window object');
+            });
+        })
     });
 });
 
 
-function callRespondTo (api, evtName) {
-    api.reqres.respondTo(evtName, onXdeCb);
+function callRespondToPostMessage (api, evtName) {
+    api.respondToPostMessage(evtName, onResponseMsg);
 
-    function onXdeCb (evt, commCb) {
-        var requestData = evt.data;
-        var result = requestData.fooInt + 1;
+    function onResponseMsg (responseData, commCb) {
+        var result = responseData.fooInt + 1;
         commCb({fooIntResult : result});
     }
 }
 
-function callRequest (api, evtName, reqData, expectedResult, done) {
-    api.reqres.request(window, evtName, reqData, onXdeCb);
+function callPostMessage (api, evtName, reqData, expectedResult, done) {
+    api.postMessage(evtName, reqData, onXdeCb, window);
 
-    function onXdeCb (evt) {
-        var responseData = evt.data;
+    function onXdeCb (err, responseData) {
+        expect(err).to.be.null;
         expect(responseData.fooIntResult).to.equal(expectedResult);
         done();
     }


### PR DESCRIPTION
There are cases when banners need to communicate with the parent, and be notified when there is a response. 

Example use:

``` javascript
// host-plugin
pluginApi.reqres.respondTo('some:ext-event', function(evt, done) {
    // do stuff with evt.data.foo
    done(someValueToBePassedDown);
});

// ext-plugin
pluginApi.reqres.request(window, 'some:ext-event', {foo:bar}, function(evt) {
    // do something with the value that was passed down through evt.data
});
```
